### PR TITLE
no config json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,25 +14,6 @@ $ npm i elm-doc-test -g
 $ elm-test init
 ```
 
-Setup
------
-
-```bash
-$ touch tests/elm-doc-test.json
-```
-
-`elm-doc-test.json` contains information on which files contain doc tests and where to find them.
-
-```json
-{
-  "root": "../src",
-  "tests": [
-    "Mock",
-    "Mock.Foo.Bar.Moo"
-  ]
-}
-```
-
 It's recommended to add `./tests/Doc` to your `.gitignore`.
 
 Writing DocTests

--- a/bin/cli-helpers.js
+++ b/bin/cli-helpers.js
@@ -63,12 +63,6 @@ function loadDocTestConfig(cb) {
       process.exit(-1);
     }
   });
-  // shell.exec('echo "[]" > ' + root + '/elm-doc-test_____.json');
-  // console.log('elm-reflection --path ' + root + ' --filter DocTest > ' + root + '/elm-doc-test_____.json');
-  // shell.exec('elm-reflection --path ' + root + ' --filter DocTest > ' + root + '/elm-doc-test_____.json');
-  // var tests = require(path.join(root, 'elm-doc-test_____.json'));
-  // shell.rm(root + '/elm-doc-test_____.json');
-  // return tests;
 }
 
 module.exports =  {

--- a/example/tests/elm-doc-test.json
+++ b/example/tests/elm-doc-test.json
@@ -1,7 +1,0 @@
-{
-  "root": "../",
-  "tests": [
-    "Mock",
-    "Mock.Foo.Bar.Moo"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   "author": "schtoeffel",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "elm-reflection": "^0.2.0",
     "fs-extra": "^1.0.0",
     "mkdirp": "^0.5.1",
+    "shelljs": "^0.7.5",
     "yargs": "^6.4.0"
   },
   "devDependencies": {

--- a/src/DocTest.elm
+++ b/src/DocTest.elm
@@ -21,16 +21,18 @@ main =
 
 
 type alias Model =
-    { root : String
-    , tests : List String
-    }
+    List Test
+
+
+type alias Test =
+    { name : String, path : String }
 
 
 init : Value -> ( Model, Cmd Msg )
 init flags =
     case decodeValue decoder flags of
         Ok model ->
-            model ! List.map (message << ReadTest) model.tests
+            model ! List.map (message << ReadTest) model
 
         Err err ->
             Debug.crash err
@@ -38,9 +40,14 @@ init flags =
 
 decoder : Decode.Decoder Model
 decoder =
-    Decode.map2 Model
-        (field "root" string)
-        (field "tests" (list string))
+    list decodeTest
+
+
+decodeTest : Decode.Decoder Test
+decodeTest =
+    Decode.map2 Test
+        (field "name" string)
+        (field "path" string)
 
 
 
@@ -48,7 +55,7 @@ decoder =
 
 
 type Msg
-    = ReadTest String
+    = ReadTest Test
     | CompileModule ( String, String )
 
 
@@ -56,7 +63,7 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         ReadTest test ->
-            model ! [ readFile test ]
+            model ! [ readFile ( test.name, test.path ) ]
 
         CompileModule ( moduleName, fileText ) ->
             let
@@ -71,7 +78,7 @@ update msg model =
 -- PORTS
 
 
-port readFile : String -> Cmd msg
+port readFile : ( String, String ) -> Cmd msg
 
 
 port writeFile : ( String, String ) -> Cmd msg


### PR DESCRIPTION
> this uses `elm-reflection` to find all doc-tests.

This means that there is no need for `elm-doc-test.json`.
It takes about `0.4s` to scan ~300 files. this means `elm-doc-test` will run `0.4s` longer.
IMO it's worth doing it, because this means we don't need any config to run test.

This is blocked by elm-reflection until it's cross-plattform (that's also why ci fails), so I have time to make it faster 😸 