### PR TITLE
Intermediate fns

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -121,6 +121,23 @@ You can specify imports, if you want to use a module or a special test util.
 -}
 ```
 
+### Intermediate Definitions
+
+You can use intermediate definitions in your example.
+:information: Unused functions don't get added to the test. This is useful if you wanna add incomplete examples to your docs.
+:warning: Intermediate definitions need a type signature!
+
+```elm
+{-|
+    isEven : Int -> Bool
+    isEven n =
+        n % 2 == 0
+
+    List.Extra.filterNot isEven [1,2,3,4] --> [1,3]
+-}
+filterNot : (a -> Bool) -> List a -> List a
+```
+
 Verify Examples
 ----------------
 

--- a/example/Mock/Foo/Bar/Moo.elm
+++ b/example/Mock/Foo/Bar/Moo.elm
@@ -5,7 +5,7 @@ module Mock.Foo.Bar.Moo exposing (..)
 
 ## Foo bar
 
-@docs foo, bar, moo
+@docs foo, bar, moo, test
 
 -}
 
@@ -45,3 +45,19 @@ bar a b c =
 moo : (a -> a -> a) -> a -> a
 moo fn x =
     fn x x
+
+
+{-|
+
+    findMe : Int
+    findMe = 42
+
+    minimizeMe : Int -> Int
+    minimizeMe n = abs (n-findMe)
+
+    test (minimizeMe 3) 39 --> True
+
+-}
+test : Int -> Int -> Bool
+test a b =
+    a == b

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -ex
-TEST_COUNT=15
+TEST_COUNT=16
 
 elm-make src/VerifyExamples.elm --output bin/elm.js
 pushd example

--- a/src/VerifyExamples/Compiler.elm
+++ b/src/VerifyExamples/Compiler.elm
@@ -1,9 +1,9 @@
 module VerifyExamples.Compiler exposing (compile)
 
-import VerifyExamples.Ast exposing (..)
 import Regex exposing (HowMany(..), regex)
 import String
 import String.Extra
+import VerifyExamples.Ast exposing (..)
 
 
 compile : String -> List TestSuite -> String
@@ -108,9 +108,9 @@ toLetIns fns =
         [] ->
             []
 
-        _ ->
+        usedFns ->
             indent 0 "let"
-                :: List.concatMap (List.map (indent 1) << String.lines << .value) fns
+                :: List.concatMap (List.map (indent 1) << String.lines << .value) usedFns
                 ++ [ indent 0 "in"
                    ]
 


### PR DESCRIPTION
> This adds documentation for intermediate definitions. \
In addition it fixes an issue where all functions got added to `let...in` not just the used ones.

resolves #31 