### PR TITLE
Allow \r\n linebreaks as well as \n

### DIFF
--- a/src/VerifyExamples/Parser.elm
+++ b/src/VerifyExamples/Parser.elm
@@ -222,7 +222,7 @@ functionNameRegex =
 
 commentRegex : Regex
 commentRegex =
-    Regex.regex "({-[^]*?-})\n([^\n]*)\\s[:=]"
+    Regex.regex "({-[^]*?-})\x0D?\n([^\x0D\n]*)\\s[:=]"
 
 
 assertionRegex : Regex


### PR DESCRIPTION
This lets elm-verify-examples work on Windows when using CRLF line endings (as happens when using 'core.autocrlf true' with Git).

(elm-format replaces '\r', with '\x0D', see avh4/elm-format#356.)

I don't think this should cause any issues on POSIX machines. There are certainly other ways to solve the issue, though, such as a pre-processing step that replaced "\r\n" with "\n" instead of modifying the parser itself.