### PR TITLE
Add support for Windows

### DIFF
--- a/bin/cli-helpers.js
+++ b/bin/cli-helpers.js
@@ -65,7 +65,7 @@ function findParentElmJson(p) {
 }
 
 function elmPathToModuleName(pathName) {
-  return pathName.slice(0, -4).replace(/\//g, ".");
+  return pathName.slice(0, -4).split(path.sep).join(".");
 }
 
 module.exports = {


### PR DESCRIPTION
`elmPathToModuleName` assumes a path separator of `/`, but windows uses `\`. 

This changes to using `.split(path.sep).join(".")` instead of a regexp replace, so that any platform will use the proper path separator